### PR TITLE
Use monotonic clock

### DIFF
--- a/domain-local-timeout.opam
+++ b/domain-local-timeout.opam
@@ -10,8 +10,10 @@ depends: [
   "dune" {>= "3.3"}
   "ocaml" {>= "5.0"}
   "psq" {>= "0.2.1"}
+  "mtime" {>= "2.0.0"}
   "mdx" {>= "1.10.0" & with-test}
   "domain-local-await" {>= "0.1.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,8 @@
  (depends
   (ocaml (>= 5.0))
   (psq (>= 0.2.1))
+  (mtime (>= 2.0.0))
   (mdx (and (>= 1.10.0) :with-test))
-  (domain-local-await (and (>= 0.1.0) :with-test))))
+  (domain-local-await (and (>= 0.1.0) :with-test))
+  (alcotest (and (>= 1.7.0) :with-test))))
 (using mdx 0.2)

--- a/src/Unix_intf.ml
+++ b/src/Unix_intf.ml
@@ -1,10 +1,9 @@
 (** Signature for a minimal subset of the [Stdlib.Unix] module needed by domain
     local timeout. *)
 module type Unix = sig
-  val gettimeofday : unit -> float
-
   type file_descr
 
+  val close : file_descr -> unit
   val read : file_descr -> bytes -> int -> int -> int
   val write : file_descr -> bytes -> int -> int -> int
   val pipe : ?cloexec:bool -> unit -> file_descr * file_descr

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name Domain_local_timeout)
  (public_name domain-local-timeout)
- (libraries psq))
+ (libraries psq mtime mtime.clock.os))

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,4 @@
 (test
  (name test)
  (modules test)
- (libraries domain-local-timeout domain-local-await threads unix))
- 
+ (libraries domain-local-timeout domain-local-await threads unix alcotest))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,27 +1,51 @@
 let () = Domain_local_timeout.set_system (module Thread) (module Unix)
 
+let test_action_raises () =
+  let open struct
+    exception Expected
+  end in
+  let domain =
+    Domain.spawn @@ fun () ->
+    let (_cancel : unit -> unit) =
+      Domain_local_timeout.set_timeoutf 0.0 @@ fun () -> raise Expected
+    in
+    Unix.sleepf 0.1;
+    Alcotest.check_raises "set_timeoutf raises" Expected (fun () ->
+        let _cancel : unit -> unit =
+          Domain_local_timeout.set_timeoutf 0.1 Fun.id
+        in
+        ())
+  in
+  Alcotest.check_raises "domain raises" Expected (fun () -> Domain.join domain)
+
 let sleepf seconds =
   let t = Domain_local_await.prepare_for_await () in
   let cancel = Domain_local_timeout.set_timeoutf seconds t.release in
   try t.await ()
   with exn ->
-    (cancel :> unit -> unit) ();
+    cancel ();
     raise exn
 
-let () =
+let test_two_timeouts () =
   let result = ref "" in
   let cancel_there =
     Domain_local_timeout.set_timeoutf 0.2 @@ fun () ->
     result := !result ^ "there!"
   in
-  (cancel_there :> unit -> unit) ();
+  cancel_there ();
   let cancel_world =
     Domain_local_timeout.set_timeoutf 0.1 @@ fun () ->
     result := !result ^ "world!"
   in
   result := !result ^ "Hello, ";
   sleepf 0.3;
-  (cancel_world :> unit -> unit) ();
-  assert (!result = "Hello, world!")
+  cancel_world ();
+  Alcotest.check' ~msg:"result is as expected" Alcotest.string
+    ~expected:"Hello, world!" ~actual:!result
 
-let () = Printf.printf "Test suite OK\n%!"
+let () =
+  Alcotest.run "Domain_local_await"
+    [
+      ("action raises", [ Alcotest.test_case "" `Quick test_action_raises ]);
+      ("two timeouts", [ Alcotest.test_case "" `Quick test_two_timeouts ]);
+    ]


### PR DESCRIPTION
This changes the default implementation to use the [mtime](https://github.com/dbuenzli/mtime) library to provide a monotonic clock.  The implementation is also improved in various ways.